### PR TITLE
Header parsing and extended response handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+PR.md 

--- a/src/error/err.rs
+++ b/src/error/err.rs
@@ -1,8 +1,10 @@
+// src/error/err.rs 
+
 use std::fmt;
 
 #[derive(Debug)]
 pub enum RequestParseError {
-    InvalidHeaderLength(usize),
+    InvalidFieldLength(usize),
     InvalidReqLine,
     MissingMethod,
     MissingPath,
@@ -14,7 +16,7 @@ pub enum RequestParseError {
 impl fmt::Display for RequestParseError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
-            RequestParseError::InvalidHeaderLength(length) => {
+            RequestParseError::InvalidFieldLength(length) => {
                 write!(
                     f,
                     "{} does not match the required length of this header.",

--- a/src/error/err.rs
+++ b/src/error/err.rs
@@ -1,4 +1,4 @@
-// src/error/err.rs 
+// src/error/err.rs
 
 use std::fmt;
 

--- a/src/http/mod.rs
+++ b/src/http/mod.rs
@@ -3,3 +3,9 @@ pub use method::Method;
 
 pub mod parser;
 pub use parser::Parser;
+
+pub mod response;
+pub use response::Response;
+
+pub mod status_codes;
+pub use status_codes::StatusCode;

--- a/src/http/parser.rs
+++ b/src/http/parser.rs
@@ -42,7 +42,7 @@ impl Parser {
 
             // if we don't get 3 items, reject it
             if parts.len() != 3 {
-                return Err(RequestParseError::InvalidHeaderLength(parts.len()));
+                return Err(RequestParseError::InvalidReqLine);
             }
 
             let method_str = parts[0];
@@ -123,6 +123,13 @@ impl Parser {
 
         true
     }
+    
+    pub fn extract_and_validate_headers(
+        &self,
+    ) {
+        unimplemented!()
+    }
+
 }
 
 impl fmt::Display for Parser {
@@ -169,10 +176,7 @@ mod parser_tests {
         let mut parser = Parser::new();
 
         let err = parser.extract_and_validate_request(line).unwrap_err();
-        match err {
-            RequestParseError::InvalidHeaderLength(n) => assert_eq!(n, 2),
-            _ => panic!("Expected InvalidHeaderLength"),
-        }
+        assert!(matches!(err, RequestParseError::InvalidReqLine));
     }
 
     #[test]

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -1,4 +1,6 @@
-// src/http/response.rs 
+// src/http/response.rs
+
+use std::fmt;
 
 pub struct Response {
     status_code: u16,
@@ -13,12 +15,48 @@ impl Response {
             status_code: 200,
             reason: "OK".to_string(),
             headers: vec![
-                ("Content-Type".to_string(),"text/plain".to_string()),
+                ("Content-Type".to_string(), "text/plain".to_string()),
                 ("Content-Length".to_string(), body.len().to_string()),
             ],
             body,
         }
     }
 
-    pub fn to_string(&self) -> String {}
+    pub fn not_found() -> Self {
+        Self {
+            status_code: 404,
+            reason: "Not Found".to_string(),
+            headers: Vec::new(),
+            body: String::new(),
+        }
+    }
+
+    pub fn bad_request() -> Self {
+        Self {
+            status_code: 400,
+            reason: "Bad Request".to_string(),
+            headers: Vec::new(),
+            body: String::new(),
+        }
+    }
+
+    pub fn internal_error() -> Self {
+        Self {
+            status_code: 500,
+            reason: "Internal Server Error".to_string(),
+            headers: Vec::new(),
+            body: String::new(),
+        }
+    }
+}
+
+impl fmt::Display for Response {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "HTTP/1.1 {} {}\r\n", self.status_code, self.reason)?;
+        
+        for (name, value) in &self.headers {
+            write!(f, "{}: {}\r\n", name, value)?;
+        }
+        write!(f, "\r\n{}", self.body)
+    }
 }

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -53,7 +53,7 @@ impl Response {
 impl fmt::Display for Response {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "HTTP/1.1 {} {}\r\n", self.status_code, self.reason)?;
-        
+
         for (name, value) in &self.headers {
             write!(f, "{}: {}\r\n", name, value)?;
         }

--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -1,0 +1,24 @@
+// src/http/response.rs 
+
+pub struct Response {
+    status_code: u16,
+    reason: String,
+    headers: Vec<(String, String)>,
+    body: String,
+}
+
+impl Response {
+    pub fn ok(body: String) -> Self {
+        Self {
+            status_code: 200,
+            reason: "OK".to_string(),
+            headers: vec![
+                ("Content-Type".to_string(),"text/plain".to_string()),
+                ("Content-Length".to_string(), body.len().to_string()),
+            ],
+            body,
+        }
+    }
+
+    pub fn to_string(&self) -> String {}
+}

--- a/src/http/status_codes.rs
+++ b/src/http/status_codes.rs
@@ -1,0 +1,41 @@
+// src/http/status_codes.rs
+
+use crate::error::RequestParseError;
+
+#[derive(Debug, Clone)]
+pub enum StatusCode {
+    Ok = 200,
+    BadRequest = 400,
+    NotFound = 404,
+    MethodNotAllowed = 405,
+    UriTooLong = 414,
+    InternalServerError = 500,
+    NotImplemented = 501,
+    HttpVersionNotSupported = 505,
+}
+
+impl StatusCode {
+    pub fn reason_phrase(&self) -> &'static str {
+        match self {
+            StatusCode::Ok => "OK",
+            StatusCode::BadRequest => "Bad Request",
+            StatusCode::NotFound => "Not Found",
+            StatusCode::MethodNotAllowed => "Method Not Allowed",
+            StatusCode::UriTooLong => "URI Too Long",
+            StatusCode::InternalServerError => "Internal Server Error",
+            StatusCode::NotImplemented => "Not Implemented",
+            StatusCode::HttpVersionNotSupported => "HTTP Version Not Supported",
+        }
+    }
+}
+
+impl From<RequestParseError> for StatusCode {
+    fn from(error: RequestParseError) -> Self {
+        match error {
+            RequestParseError::UnsupportedMethod(_) => StatusCode::MethodNotAllowed,
+            RequestParseError::InvalidHttpVersion(_) => StatusCode::HttpVersionNotSupported,
+            RequestParseError::InvalidFieldLength(_) => StatusCode::UriTooLong,
+            _ => StatusCode::BadRequest,
+        }
+    }
+}

--- a/src/http/status_codes.rs
+++ b/src/http/status_codes.rs
@@ -17,14 +17,14 @@ pub enum StatusCode {
 impl StatusCode {
     pub fn reason_phrase(&self) -> &'static str {
         match self {
-            StatusCode::Ok => "OK",
-            StatusCode::BadRequest => "Bad Request",
-            StatusCode::NotFound => "Not Found",
-            StatusCode::MethodNotAllowed => "Method Not Allowed",
-            StatusCode::UriTooLong => "URI Too Long",
-            StatusCode::InternalServerError => "Internal Server Error",
-            StatusCode::NotImplemented => "Not Implemented",
-            StatusCode::HttpVersionNotSupported => "HTTP Version Not Supported",
+            StatusCode::Ok => "OK\n",
+            StatusCode::BadRequest => "Bad Request\n",
+            StatusCode::NotFound => "Not Found\n",
+            StatusCode::MethodNotAllowed => "Method Not Allowed\n",
+            StatusCode::UriTooLong => "URI Too Long\n",
+            StatusCode::InternalServerError => "Internal Server Error\n",
+            StatusCode::NotImplemented => "Not Implemented\n",
+            StatusCode::HttpVersionNotSupported => "HTTP Version Not Supported\n",
         }
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ fn main() -> std::io::Result<()> {
     for stream in listener.incoming() {
         match stream {
             Ok(stream) => {
-                handle_connection(stream)?;
+                handle_request(stream)?;
             }
             Err(e) => eprintln!("Connection failed: {e}"),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use rustline::server::serve::handle_connection;
+use rustline::server::serve::handle_request;
 use std::net::TcpListener;
 
 fn main() -> std::io::Result<()> {

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -15,13 +15,13 @@ pub fn handle_request(mut stream: TcpStream) -> Result<()> {
     match parser.extract_and_validate_request(&request_str) {
         Ok((method, path, major, minor)) => {
             println!("{method:?} {path} HTTP/{major}.{minor}");
-            let response = Response::ok("PING".to_string());
-            stream.write_all(response.as_bytes())?;
+            let response = Response::ok("Hello, World!\n".to_string());
+            stream.write_all(response.to_string().as_bytes())?;
             stream.flush()?;
         }
         Err(parse_error) => {
             eprintln!("{parse_error}");
-            let response = "HTTP/1.1 400 Bad Request\r\n\r\nBad Request";
+            let response = "HTTP/1.1 400 Bad Request\r\n\r\nBad Request\n";
             stream.write_all(response.as_bytes())?;
             stream.flush()?;
         }

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -1,11 +1,12 @@
 // src/server/serve.rs
+
 // use crate::error::RequestParseError;
-use crate::http::Parser;
+use crate::http::{Parser, Response};
 use std::io::Result;
 use std::io::prelude::*;
 use std::net::TcpStream;
 
-pub fn handle_connection(mut stream: TcpStream) -> Result<()> {
+pub fn handle_request(mut stream: TcpStream) -> Result<()> {
     let mut buffer = [0; 512];
     let mut parser = Parser::new();
     let n = stream.read(&mut buffer)?;
@@ -13,16 +14,16 @@ pub fn handle_connection(mut stream: TcpStream) -> Result<()> {
 
     match parser.extract_and_validate_request(&request_str) {
         Ok((method, path, major, minor)) => {
-            println!("Parsed: {method:?} {path} HTTP/{major}.{minor}");
-            // TODO: Successful requests
-            let response = "HTTP/1.1 200 OK\r\n\r\nHello, World!";
+            println!("{method:?} {path} HTTP/{major}.{minor}");
+            let response = Response::ok("PING".to_string());
             stream.write_all(response.as_bytes())?;
+            stream.flush()?;
         }
         Err(parse_error) => {
-            eprintln!("Parse error: {parse_error}");
-            // TODO: Error responsee
+            eprintln!("{parse_error}");
             let response = "HTTP/1.1 400 Bad Request\r\n\r\nBad Request";
             stream.write_all(response.as_bytes())?;
+            stream.flush()?;
         }
     }
 

--- a/src/server/serve.rs
+++ b/src/server/serve.rs
@@ -15,14 +15,21 @@ pub fn handle_request(mut stream: TcpStream) -> Result<()> {
     match parser.extract_and_validate_request(&request_str) {
         Ok((method, path, major, minor)) => {
             println!("{method:?} {path} HTTP/{major}.{minor}");
-            let response = Response::ok("Hello, World!\n".to_string());
+
+            let response = match path.as_str() {
+                "/" => Response::ok("Hello, World!\n".to_string()),
+                "/ping" => Response::ok("pong\n".to_string()),
+                "/health" => Response::ok("Server is healthy\n".to_string()),
+                _ => Response::not_found(),
+            };
+
             stream.write_all(response.to_string().as_bytes())?;
             stream.flush()?;
         }
         Err(parse_error) => {
             eprintln!("{parse_error}");
-            let response = "HTTP/1.1 400 Bad Request\r\n\r\nBad Request\n";
-            stream.write_all(response.as_bytes())?;
+            let response = Response::bad_request();
+            stream.write_all(response.to_string().as_bytes())?;
             stream.flush()?;
         }
     }


### PR DESCRIPTION
- Tests for parsing
- Versioning checks rejecting anything but 1.1 or 1.0
- Corrected `InvalidHeaderLength` to `InvalidFieldLength`
- Extract headers (plain text only currently)
- Unit tests for parser
- Abstracted response structure into `response.rs`
- Status Codes mapped to errors 
- `handle_connection` changed to `handle_request` for accuracy
- Added simple routes to test 