### PR TITLE
File writing via POST and runtime refactors

### DIFF
--- a/src/http/response.rs
+++ b/src/http/response.rs
@@ -11,7 +11,6 @@ pub struct Response {
 }
 
 impl Response {
-
     pub fn with_status(status_code: u16, reason: &str, body: String) -> Self {
         let headers = vec![
             ("Content-type".to_string(), "text/plain".to_string()),
@@ -26,16 +25,20 @@ impl Response {
         }
     }
 
-    pub fn ok(body: String) -> Self {
-        Self::with_status(200, "OK", body)
+    pub fn ok(status_code: u16, body: String) -> Self {
+        Self::with_status(status_code, "OK", body)
     }
 
     pub fn not_found() -> Self {
-        Self::with_status(404, "Not Found", String::new())    
+        Self::with_status(404, "Not Found", String::new())
     }
 
     pub fn bad_request() -> Self {
         Self::with_status(400, "Bad Request", String::new())
+    }
+
+    pub fn unsupported_method() -> Self {
+        Self::with_status(405, "Unsupported Method", String::new())
     }
 
     pub fn internal_error() -> Self {
@@ -43,7 +46,11 @@ impl Response {
     }
 
     pub fn set_header(&mut self, key: &str, value: &str) {
-        if let Some(existing) = self.headers.iter_mut().find(|(k, _)| k.eq_ignore_ascii_case(key)) {
+        if let Some(existing) = self
+            .headers
+            .iter_mut()
+            .find(|(k, _)| k.eq_ignore_ascii_case(key))
+        {
             existing.1 = value.to_string();
         } else {
             self.headers.push((key.to_string(), value.to_string()));
@@ -52,7 +59,7 @@ impl Response {
 
     pub fn content_type(mut self, value: &str) -> Self {
         self.set_header("Content-Type", value);
-        self 
+        self
     }
 
     pub fn add_header(mut self, key: &str, value: &str) -> Self {

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,5 +2,5 @@ use rustline::server::runtime::run;
 
 #[tokio::main]
 async fn main() {
-    run("127.0.0.1:8080".to_string()).await.unwrap(); 
+    run().await.unwrap(); 
 }

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -6,10 +6,10 @@ use std::error::Error;
 const USAGE: &str = r#"
 USAGE: cargo run <command> [args]
 
-Options: 
-        ns                 Run server with no directory specified
-        directory <DIR>    File serving directory (default: .)
-        -h, help           Show This help message
+Commands: 
+        ns [PORT]                Run server with no directory specified
+        dir <DIR> [PORT]         File serving directory (default: .)
+        -h, help                 Show This help message
 "#;
 
 macro_rules! run_server {
@@ -28,7 +28,7 @@ macro_rules! run_server {
     }};
 }
 
-pub async fn run(addr: String) -> Result<(), Box<dyn Error>> {
+pub async fn run() -> Result<(), Box<dyn Error>> {
     let args: Vec<String> = env::args().collect();
 
     if args.len() < 2 {
@@ -36,19 +36,29 @@ pub async fn run(addr: String) -> Result<(), Box<dyn Error>> {
         std::process::exit(1);
     }
 
+    let mut port = "8080".to_string(); // default port 
+
     match args[1].as_str() {
-        "directory" => {
+        "dir" | "directory" => {
+            if args.len() >= 4 {
+                port = args[3].clone();
+            }
             let dir = if args.len() >= 3 {
                 args[2].clone()
             } else {
                 ".".to_string()
             };
+            let addr = format!("127.0.0.1:{port}");
             let server = Server::new_with_directory(dir.clone());
             let label = format!("In directory: {dir}");
             run_server!(server, addr, label);
         }
 
         "ns" => {
+            if args.len() >= 3 {
+                port = args[2].clone();
+            }
+            let addr = format!("127.0.0.1:{port}");
             let server = Server::new();
             let label = String::from("Serving with no specified directory");
             run_server!(server, addr, label);


### PR DESCRIPTION
## Overview
#### Runtime
Refactored the runtime to take an optional port passed into the commands by the user- default behavior binds port to 8080.
#### POST
Laid out a general file writer with the `/files` endpoint when using POST. This implementation is broken in a couple ways right now: 
    - `Content-Type` returns 0 since we aren't actually reading in the body. We need to let body prefer `Vec<u8>` or something so that we can return the correct bytes of our written file
            - <img width="435" height="189" alt="image" src="https://github.com/user-attachments/assets/f6f76d38-a6f8-4889-907d-3c6e20187b87" />\
    - I refactored `response.rs` pass in a broad `status_code` to the `OK` type- this is not ideal because it's not quite within scope semantically to allow the caller to arbitrarily pass in any status code. Ideally, we'd do something like `with_status` that has the correct types in spec that can then be passed in based on what we're doing.
    - This could _probably_ be okay assuming I'd be the only one touching this code. In either situation, we're trusting the caller knows what status code to call for each respective method. The only difference here is not allowing silent fails because someone (by someone I mean me) decided to call a `200` status on a POST file write. 