### PR TITLE
Handle label when running without a port

### DIFF
--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -37,11 +37,13 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
     }
 
     let mut port = "8080".to_string(); // default port 
+    let mut used_default_port = true;
 
     match args[1].as_str() {
         "dir" | "directory" => {
             if args.len() >= 4 {
                 port = args[3].clone();
+                used_default_port = false;
             }
             let dir = if args.len() >= 3 {
                 args[2].clone()
@@ -50,17 +52,26 @@ pub async fn run() -> Result<(), Box<dyn Error>> {
             };
             let addr = format!("127.0.0.1:{port}");
             let server = Server::new_with_directory(dir.clone());
-            let label = format!("In directory: {dir}");
+            let label = if used_default_port {
+                format!("In directory: {dir} (default port: {port})")
+            } else {
+                format!("In directory: {dir}")
+            };
             run_server!(server, addr, label);
         }
 
         "ns" => {
             if args.len() >= 3 {
                 port = args[2].clone();
+                used_default_port = false;
             }
             let addr = format!("127.0.0.1:{port}");
             let server = Server::new();
-            let label = String::from("Serving with no specified directory");
+            let label = if used_default_port {
+                String::from("Serving with no specified directory (default port 8080)")
+            } else {
+                String::from("Serving with no specified directory")
+            };
             run_server!(server, addr, label);
         }
 

--- a/tests/load_test.rs
+++ b/tests/load_test.rs
@@ -5,6 +5,7 @@ use tokio::{
     net::TcpStream,
 };
 
+// TODO: Refactor to pass a port into a test 
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn integration_load_test() {
     tokio::spawn(async {


### PR DESCRIPTION
Adjust label to indicate the default port when a user doesn't pass a port through. Also added a TODO comment for our one test to adjust this later on.