### PR TITLE
Seperate CLI parsing from runtime logic

### DIFF
--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,0 +1,2 @@
+pub mod parse;
+pub use parse::*;

--- a/src/cli/parse.rs
+++ b/src/cli/parse.rs
@@ -1,0 +1,37 @@
+use crate::server::{Config, Mode};
+
+pub fn parse_args() -> Result<Config, String> {
+    let args: Vec<String> = std::env::args().collect();
+
+    if args.len() < 2 {
+        return Err("Missing command".into());
+    }
+
+    match args[1].as_str() {
+        "dir" | "directory" => {
+            let dir = args.get(2).cloned().unwrap_or_else(|| ".".to_string());
+            let port = args
+                .get(3)
+                .and_then(|s| s.parse::<u16>().ok())
+                .unwrap_or(8080);
+            Ok(Config {
+                mode: Mode::Directory,
+                port,
+                directory: Some(dir),
+            })
+        }
+        "ns" => {
+            let port = args
+                .get(2)
+                .and_then(|s| s.parse::<u16>().ok())
+                .unwrap_or(8080);
+            Ok(Config {
+                mode: Mode::NoDir,
+                port,
+                directory: None,
+            })
+        }
+        "-h" | "help" => Err("help".into()),
+        other => Err(format!("Unknown option: {other}")),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod cli;
 pub mod error;
 pub mod http;
 pub mod server;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,21 @@
-use rustline::server::runtime::run;
+use rustline::cli::parse_args;
+use rustline::server::runtime::{USAGE, run_with};
 
 #[tokio::main]
 async fn main() {
-    run().await.unwrap();
+    match parse_args() {
+        Ok(cfg) => {
+            if let Err(e) = run_with(cfg).await {
+                eprintln!("Server error: {e}");
+                std::process::exit(1);
+            }
+        }
+        Err(ref e) if e == "help" => {
+            println!("{USAGE}");
+        }
+        Err(e) => {
+            eprintln!("{e}\n{USAGE}");
+            std::process::exit(1);
+        }
+    }
 }

--- a/src/server/runtime.rs
+++ b/src/server/runtime.rs
@@ -1,88 +1,54 @@
 use crate::server::serve::Server;
-use std::env;
 use std::error::Error;
 use tokio::net::TcpListener;
 
-const USAGE: &str = r#"
+pub const USAGE: &str = r#"
 USAGE: cargo run <command> [args]
 
-Commands: 
-        ns [PORT]                Run server with no directory specified
-        dir <DIR> [PORT]         File serving directory (default: .)
-        -h, help                 Show This help message
+Commands:
+    ns [PORT]            Run server with no directory specified
+    dir <DIR> [PORT]     File serving directory (default: .)
+    -h, help             Show this help message
 "#;
 
-macro_rules! run_server {
-    ($server:expr, $addr:expr, $label:expr) => {{
-        let listener = TcpListener::bind(&$addr).await?;
-        println!("Listening on http://{}\n{}", $addr, $label);
-        loop {
-            let (stream, _) = listener.accept().await?;
-            let server = $server.clone();
-            tokio::spawn(async move {
-                if let Err(e) = server.handle_request(stream).await {
-                    eprintln!("Error: {}", e);
-                }
-            });
-        }
-    }};
+#[derive(Clone, Debug)]
+pub enum Mode {
+    NoDir,
+    Directory,
 }
 
-pub async fn run() -> Result<(), Box<dyn Error>> {
-    let args: Vec<String> = env::args().collect();
+#[derive(Clone, Debug)]
+pub struct Config {
+    pub mode: Mode,
+    pub port: u16,
+    pub directory: Option<String>,
+}
 
-    if args.len() < 2 {
-        eprintln!("{}", USAGE);
-        std::process::exit(1);
-    }
+/// Launch the HTTP server with the given configuration.
+///
+/// This function does **not** parse CLI arguments or exit the process,
+/// so it’s safe to call from integration tests.
+pub async fn run_with(cfg: Config) -> Result<(), Box<dyn Error>> {
+    let addr = format!("127.0.0.1:{}", cfg.port);
+    let listener = TcpListener::bind(&addr).await?;
 
-    let mut port = "8080".to_string(); // default port 
-    let mut used_default_port = true;
+    let server = match cfg.mode {
+        Mode::Directory => {
+            let dir = cfg.directory.clone().unwrap_or_else(|| ".".into());
+            Server::new_with_directory(dir)
+        }
+        Mode::NoDir => Server::new(),
+    };
 
-    match args[1].as_str() {
-        "dir" | "directory" => {
-            if args.len() >= 4 {
-                port = args[3].clone();
-                used_default_port = false;
+    println!("Listening on http://{}", addr);
+
+    loop {
+        let (stream, _) = listener.accept().await?;
+        let server = server.clone();
+        tokio::spawn(async move {
+            if let Err(e) = server.handle_request(stream).await {
+                eprintln!("Error: {}", e);
             }
-            let dir = if args.len() >= 3 {
-                args[2].clone()
-            } else {
-                ".".to_string()
-            };
-            let addr = format!("127.0.0.1:{port}");
-            let server = Server::new_with_directory(dir.clone());
-            let label = if used_default_port {
-                format!("In directory: {dir} (default port: {port})")
-            } else {
-                format!("In directory: {dir}")
-            };
-            run_server!(server, addr, label);
-        }
-
-        "ns" => {
-            if args.len() >= 3 {
-                port = args[2].clone();
-                used_default_port = false;
-            }
-            let addr = format!("127.0.0.1:{port}");
-            let server = Server::new();
-            let label = if used_default_port {
-                String::from("Serving with no specified directory (default port 8080)")
-            } else {
-                String::from("Serving with no specified directory")
-            };
-            run_server!(server, addr, label);
-        }
-
-        "-h" | "help" => {
-            println!("{USAGE}");
-            Ok(())
-        }
-
-        _ => {
-            eprintln!("Unknown option: {}\n{USAGE}", args[1]);
-            std::process::exit(1);
-        }
+        });
     }
 }

--- a/tests/load_test.rs
+++ b/tests/load_test.rs
@@ -1,15 +1,19 @@
-use rustline::server::runtime::run;
+use rustline::server::{Config, Mode, run_with};
 use std::time::Duration;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     net::TcpStream,
 };
 
-// TODO: Refactor to pass a port into a test
 #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
 async fn integration_load_test() {
+    let cfg = Config {
+        mode: Mode::NoDir,
+        port: 9000,
+        directory: None,
+    };
     tokio::spawn(async {
-        run("127.0.0.1:8080".to_string()).await.unwrap();
+        run_with(cfg).await.unwrap();
     });
     tokio::time::sleep(Duration::from_secs(1)).await;
 


### PR DESCRIPTION
Refactored the server startup by extracting CLI parsing into a new `cli` module with `parse_args`, leaving `main.rs` responsible only for wiring arguments to `run_with`.
This separation makes the entrypoint cleaner and keeps parsing logic testable and independent of the runtime.
